### PR TITLE
fix: correct CORS origin validation to prevent misconfiguration

### DIFF
--- a/internal/infrastructure/http/middleware/middleware.go
+++ b/internal/infrastructure/http/middleware/middleware.go
@@ -91,12 +91,17 @@ func Logging(next http.Handler) http.Handler {
 
 // CORS applies CORS headers based on configuration.
 func CORS(cfg config.SecurityConfig) func(http.Handler) http.Handler {
-	origins := strings.Join(cfg.CORSAllowedOrigins, ",")
 	methods := strings.Join(cfg.CORSAllowedMethods, ",")
 	headers := strings.Join(cfg.CORSAllowedHeaders, ",")
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Access-Control-Allow-Origin", origins)
+			requestOrigin := r.Header.Get("Origin")
+			for _, allowed := range cfg.CORSAllowedOrigins {
+				if requestOrigin == allowed {
+					w.Header().Set("Access-Control-Allow-Origin", requestOrigin)
+					break
+				}
+			}
 			w.Header().Set("Access-Control-Allow-Methods", methods)
 			w.Header().Set("Access-Control-Allow-Headers", headers)
 			if r.Method == http.MethodOptions {


### PR DESCRIPTION
## Security Fix: CORS Origin Validation

### Issue
The current CORS implementation joins multiple allowed origins into a 
single comma-separated string and sets it as the 
Access-Control-Allow-Origin header value.

Browsers only accept a single origin value or * in this header. 
A comma-separated list is invalid per the CORS specification (RFC 6454).

### Impact
1. Broken functionality; legitimate cross-origin requests from 
   allowed origins silently fail
2. Security misconfiguration; false sense of protection while 
   CORS is effectively not enforced
3. In a financial platform handling M-Pesa transactions and wallet 
   operations, this could expose authenticated user data to 
   cross-origin attacks if the header were interpreted permissively 
   by any client

### Regulatory Context
Kenya Data Protection Act 2019 and Nigeria NDPR require adequate 
technical measures to protect user data. CORS misconfiguration 
directly undermines this requirement.

### Fix
Dynamically reflect the matched request origin instead of joining 
all origins into a single header value.

### References
- CORS specification RFC 6454
- CWE-942
- OWASP Security Misconfiguration (A05:2021)
- PortSwigger Web Security Academy; CORS vulnerabilities